### PR TITLE
V3.0.0.0

### DIFF
--- a/modules/dmrpp_service/main.tf
+++ b/modules/dmrpp_service/main.tf
@@ -12,7 +12,7 @@ module "dmrpp_ecs_task_module" {
 }
 
 module "dmrpp_service" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.21.0/terraform-aws-cumulus-ecs-service.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v2.0.1/terraform-aws-cumulus-ecs-service.zip"
 
 
   prefix = var.prefix

--- a/modules/dmrpp_service/main.tf
+++ b/modules/dmrpp_service/main.tf
@@ -12,7 +12,7 @@ module "dmrpp_ecs_task_module" {
 }
 
 module "dmrpp_service" {
-  source = "https://github.com/nasa/cumulus/releases/download/v2.0.1/terraform-aws-cumulus-ecs-service.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v3.0.0/terraform-aws-cumulus-ecs-service.zip"
 
 
   prefix = var.prefix


### PR DESCRIPTION
I tested this new version by updating the module in my Cumulus 2.0.7 deployment to:

```
module "dmrpp-generator" {
  // Required parameters
  source = "git::https://github.com/lindsleycj/dmrpp-generator.git?ref=v3.0.0.0"

```

and then ingesting a granule.  It generated a valid dmrpp file.