### PR TITLE
remove log2elasticsearch lambda reference and replaced with optional …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
-- **PODAAC-3366**
-  - Modify DMRPP to be cumulus 7.x compliant.
+- https://github.com/ghrcdaac/dmrpp-generator/issues/12
+  - Modification to fix the above issue.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - xxxx-xx-xx
+
+### Added
+### Changed
+- **PODAAC-3366**
+  - Modify DMRPP to be cumulus 7.x compliant.
+### Deprecated
+### Removed
+### Fixed
+### Security

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ module "dmrpp-generator" {
   // Required parameters
   source = "https://github.com/ghrcdaac/dmrpp-generator/releases/download/<tag_num>/dmrpp-generator.zip"
   cluster_arn = module.cumulus.ecs_cluster_arn
-  log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
   region = var.region
   prefix = var.prefix
   docker_image = var.dmrpp-generator-docker-image
@@ -49,6 +48,8 @@ module "dmrpp-generator" {
   desired_count = 1  // Default to 1
   docker_image = "ghrcdaac/dmrpp-generator:<tag_num>"
 } 
+
+log_destination_arn = var.aws_log_mechanism (optional)
 ```
 In [variables.tf](https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf) 
 file you need to define 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "dmrpp_service" {
   prefix = var.prefix
   cluster_arn                           = var.cluster_arn
   desired_count                         = var.desired_count
-  log2elasticsearch_lambda_function_arn = var.log2elasticsearch_lambda_function_arn
+  log_destination_arn = var.log_destination_arn
   docker_image = var.docker_image
   cpu                = var.cpu
   memory_reservation = var.memory_reservation

--- a/modules/dmrpp_service/main.tf
+++ b/modules/dmrpp_service/main.tf
@@ -12,7 +12,7 @@ module "dmrpp_ecs_task_module" {
 }
 
 module "dmrpp_service" {
-  source = "https://github.com/nasa/cumulus/releases/download/v5.0.1/terraform-aws-cumulus-ecs-service.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v8.0.0/terraform-aws-cumulus-ecs-service.zip"
 
 
   prefix = var.prefix
@@ -21,10 +21,10 @@ module "dmrpp_service" {
   cluster_arn                           = var.cluster_arn
   desired_count                         = var.desired_count
   image                                 = var.docker_image
-  log2elasticsearch_lambda_function_arn = var.log2elasticsearch_lambda_function_arn
-  cpu                = var.cpu
-  memory_reservation = var.memory_reservation
-  volumes            = var.volumes
+  log_destination_arn                   = var.log_destination_arn
+  cpu                                   = var.cpu
+  memory_reservation                    = var.memory_reservation
+  volumes                               = var.volumes
 
   environment = {
     AWS_DEFAULT_REGION = var.region

--- a/modules/dmrpp_service/variables.tf
+++ b/modules/dmrpp_service/variables.tf
@@ -4,6 +4,10 @@ variable "cpu" {}
 variable "memory_reservation" {}
 variable "region" {}
 variable "cluster_arn" {}
-variable "log2elasticsearch_lambda_function_arn" {}
+variable "log_destination_arn" {
+  type        = string
+  default     = null
+  description = "A shared AWS:Log:Destination that receives logs in log_groups"
+}
 variable "docker_image" {}
 variable "volumes" {}

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,11 @@ variable "memory_reservation" {
   default = 900
 }
 variable "cluster_arn" {}
-variable "log2elasticsearch_lambda_function_arn" {}
+variable "log_destination_arn" {
+  type        = string
+  default     = null
+  description = "A shared AWS:Log:Destination that receives logs in log_groups"
+}
 variable "docker_image" {
   default = "ghrcdaac/dmrpp-generator:latest"
 }


### PR DESCRIPTION
This is a draft for PODAAC team internal review

* Integration testing with PODAAC cumulus-tf project's feature/PODAAC-3366 branch which is on cumulus v8.0.0